### PR TITLE
Update footer link style (accessibility update).

### DIFF
--- a/wp-content/themes/mlibrary-twentyseventeen/style.css
+++ b/wp-content/themes/mlibrary-twentyseventeen/style.css
@@ -93,6 +93,15 @@ h1, h2, h3, h4, h5, h6 {
 	color: white;
 }
 
+.falafel-footer a {
+   color: white;
+   text-decoration: underline;
+}
+
+.falafel-footer a:hover {
+  text-decoration: underline; }
+}
+
 .falafel-footer h2.widget-title {
 	color: white;
 }


### PR DESCRIPTION
It was noted in the 2017 theme that the footer links hadn't been updated to match our base CSS/be accessible. 