### PR TITLE
Add support for Post Loop in theme MICHELP-30

### DIFF
--- a/wp-content/themes/twentyseventeen/template-parts/loop.php
+++ b/wp-content/themes/twentyseventeen/template-parts/loop.php
@@ -24,4 +24,3 @@
 				get_template_part( 'template-parts/post/content', 'none' );
 
 			endif;
-			?>

--- a/wp-content/themes/twentyseventeen/template-parts/loop.php
+++ b/wp-content/themes/twentyseventeen/template-parts/loop.php
@@ -1,0 +1,27 @@
+	<?php
+			if ( have_posts() ) :
+
+				/* Start the Loop */
+				while ( have_posts() ) : the_post();
+
+					/*
+					 * Include the Post-Format-specific template for the content.
+					 * If you want to override this in a child theme, then include a file
+					 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
+					 */
+					get_template_part( 'template-parts/post/content', get_post_format() );
+
+				endwhile;
+
+				the_posts_pagination( array(
+					'prev_text' => twentyseventeen_get_svg( array( 'icon' => 'arrow-left' ) ) . '<span class="screen-reader-text">' . __( 'Previous page', 'twentyseventeen' ) . '</span>',
+					'next_text' => '<span class="screen-reader-text">' . __( 'Next page', 'twentyseventeen' ) . '</span>' . twentyseventeen_get_svg( array( 'icon' => 'arrow-right' ) ),
+					'before_page_number' => '<span class="meta-nav screen-reader-text">' . __( 'Page', 'twentyseventeen' ) . ' </span>',
+				) );
+
+			else :
+
+				get_template_part( 'template-parts/post/content', 'none' );
+
+			endif;
+			?>


### PR DESCRIPTION
Added a loop.php to the template-parts folder so that Post Loop can find it in the directory. This only affects the 2017 theme, not the Falafel theme. The widget only looks two levels down from the theme folder.

MICHELP-30